### PR TITLE
Support MiFare Classic Mini

### DIFF
--- a/mfdread.py
+++ b/mfdread.py
@@ -136,7 +136,7 @@ def print_info(data):
     data_size = len(data)
 
     if data_size not in {4096, 1024, 320}:
-        sys.exit("Wrong file size: %d bytes.\nOnly 1024 or 4096 allowed." % len(data))
+        sys.exit("Wrong file size: %d bytes.\nOnly 320, 1024 or 4096 bytes allowed." % len(data))
 
     if Options.FORCE_1K:
         data_size = 1024

--- a/mfdread.py
+++ b/mfdread.py
@@ -135,7 +135,7 @@ def print_info(data):
 
     data_size = len(data)
 
-    if data_size not in {4096, 1024}:
+    if data_size not in {4096, 1024, 320}:
         sys.exit("Wrong file size: %d bytes.\nOnly 1024 or 4096 allowed." % len(data))
 
     if Options.FORCE_1K:


### PR DESCRIPTION
Thanks for this great tool! :-)

This super short PR adds support for MiFare Classic Mini ([basically a MiFare classic with only 320 bytes of storage](https://en.wikipedia.org/wiki/MIFARE#MIFARE_Classic_family)).